### PR TITLE
Fix consecutive newlines in heredoc not being preserved

### DIFF
--- a/lib/bashly.rb
+++ b/lib/bashly.rb
@@ -16,7 +16,7 @@ module Bashly
   ]
 
   autoloads 'bashly/concerns', %i[
-    AssetHelper Completions Renderable ValidationHelpers
+    AssetHelper Completions LintHelper Renderable ValidationHelpers
   ]
 
   module Script

--- a/lib/bashly/concerns/lint_helper.rb
+++ b/lib/bashly/concerns/lint_helper.rb
@@ -1,0 +1,79 @@
+module Bashly
+  # A helper class, used by the `String#lint` extension.
+  # It will remove consecutive newlines and hidden comments from a string
+  # unless the line is within a heredoc block.
+  class LintHelper
+    attr_reader :lines, :output, :marker
+
+    def initialize(script)
+      @lines = script.lines
+      @output = []
+      @marker = nil
+      @previous_blank = false
+    end
+
+    def lint
+      lines.each { |line| process_line line }
+      output.join
+    end
+
+  private
+
+    def process_line(line)
+      if inside_heredoc?
+        handle_heredoc_line line
+      else
+        handle_regular_line line
+      end
+    end
+
+    def handle_heredoc_line(line)
+      output << line
+      reset_marker if heredoc_closed? line
+    end
+
+    def handle_regular_line(line)
+      set_heredoc_state line
+      return handle_blank_line if blank? line
+      return if comment? line
+
+      output << line
+      @previous_blank = false
+    end
+
+    def handle_blank_line
+      return if @previous_blank
+
+      output << "\n"
+      @previous_blank = true
+    end
+
+    def blank?(line)
+      line.strip.empty?
+    end
+
+    def comment?(line)
+      line =~ /^\s*##/
+    end
+
+    def set_heredoc_state(line)
+      @marker = extract_heredoc_marker line unless inside_heredoc?
+    end
+
+    def extract_heredoc_marker(line)
+      line =~ /<<-?\s*['"]?(\w+)['"]?/ ? $1 : nil
+    end
+
+    def inside_heredoc?
+      !!marker
+    end
+
+    def heredoc_closed?(line)
+      line.strip == marker
+    end
+
+    def reset_marker
+      @marker = nil
+    end
+  end
+end

--- a/lib/bashly/extensions/string.rb
+++ b/lib/bashly/extensions/string.rb
@@ -45,7 +45,7 @@ class String
   end
 
   def lint
-    gsub(/\s+\n/m, "\n\n").lines.grep_v(/^\s*##/).join
+    Bashly::LintHelper.new(self).lint
   end
 
   def remove_front_matter

--- a/spec/approvals/examples/stacktrace
+++ b/spec/approvals/examples/stacktrace
@@ -51,5 +51,5 @@ Examples:
 
 Stack trace:
 	from ./download:15 in `root_command`
-	from ./download:260 in `run`
-	from ./download:266 in `main`
+	from ./download:259 in `run`
+	from ./download:265 in `main`


### PR DESCRIPTION
cc #644

The referenced issue discovered an edge case with heredocs, where consecutive newlines are being squashed to a single newline.

The solution was to expand the linting operation, from a simple single line that replaced multiple newlines with one, to a full blown `LintHelper` class, similar to the `IndentationHelper` class (for heredoc-aware indentation).

---

## Tasks

- [x] Code implementation
- [x] Tests pass
- [ ] shellcheck and shfmt pass
- [ ] Spec implementation