### PR TITLE
Update bash version bouncer to require bash 4.2

### DIFF
--- a/lib/bashly/libraries/strings/strings.yml
+++ b/lib/bashly/libraries/strings/strings.yml
@@ -40,6 +40,6 @@ examples_caption_on_error: 'examples:'
 disallowed_flag: "%{name} must be one of: %{allowed}"
 disallowed_argument: "%{name} must be one of: %{allowed}"
 disallowed_environment_variable: "%{name} environment variable must be one of: %{allowed}"
-unsupported_bash_version: "bash version 4 or higher is required"
+unsupported_bash_version: "bash version 4.2 or higher is required"
 validation_error: "validation error in %s:\\n%s"
 environment_variable_validation_error: "validation error in environment variable %s:\\n%s"

--- a/lib/bashly/views/wrapper/bash3_bouncer.gtx
+++ b/lib/bashly/views/wrapper/bash3_bouncer.gtx
@@ -1,6 +1,6 @@
 = view_marker
 
-> if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 2) )); then
+> if ((BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 2))); then
 >   printf "{{ strings[:unsupported_bash_version] }}\n" >&2
 >   exit 1
 > fi

--- a/lib/bashly/views/wrapper/bash3_bouncer.gtx
+++ b/lib/bashly/views/wrapper/bash3_bouncer.gtx
@@ -1,7 +1,10 @@
 = view_marker
 
-> if [[ "${BASH_VERSINFO:-0}" -lt 4 ]]; then
+> if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 2) )); then
 >   printf "{{ strings[:unsupported_bash_version] }}\n" >&2
 >   exit 1
 > fi
 > 
+
+
+

--- a/spec/approvals/bash/error
+++ b/spec/approvals/bash/error
@@ -1,1 +1,1 @@
-bash version 4 or higher is required
+bash version 4.2 or higher is required

--- a/spec/approvals/script/wrapper/code
+++ b/spec/approvals/script/wrapper/code
@@ -3,8 +3,8 @@
 # Modifying it manually is not recommended
 
 # :wrapper.bash3_bouncer
-if [[ "${BASH_VERSINFO:-0}" -lt 4 ]]; then
-  printf "bash version 4 or higher is required\n" >&2
+if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 2) )); then
+  printf "bash version 4.2 or higher is required\n" >&2
   exit 1
 fi
 

--- a/spec/approvals/script/wrapper/code
+++ b/spec/approvals/script/wrapper/code
@@ -3,7 +3,7 @@
 # Modifying it manually is not recommended
 
 # :wrapper.bash3_bouncer
-if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 2) )); then
+if ((BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 2))); then
   printf "bash version 4.2 or higher is required\n" >&2
   exit 1
 fi


### PR DESCRIPTION
Before this PR, the bash version bouncer required version 4.0 for the associative arrays.

However, the `[[ -v varname ]]`, which is used in bashly's templates, and is a common requirement for modern bash scripts was only introduced in bash version 4.2.


