### PR TITLE
Fix function name in root command comment

### DIFF
--- a/examples/catch-all/src/root_command.sh
+++ b/examples/catch-all/src/root_command.sh
@@ -1,5 +1,5 @@
 echo "# This file is located at 'src/root_command.sh'."
 echo "# It contains the implementation for the 'download' command."
-echo "# The code you write here will be wrapped by a function named 'download_command()'."
+echo "# The code you write here will be wrapped by a function named 'root_command()'."
 echo "# Feel free to edit this file; your changes will persist when regenerating."
 inspect_args

--- a/examples/custom-strings/src/root_command.sh
+++ b/examples/custom-strings/src/root_command.sh
@@ -1,5 +1,5 @@
 echo "# This file is located at 'src/root_command.sh'."
 echo "# It contains the implementation for the 'download' command."
-echo "# The code you write here will be wrapped by a function named 'download_command()'."
+echo "# The code you write here will be wrapped by a function named 'root_command()'."
 echo "# Feel free to edit this file; your changes will persist when regenerating."
 inspect_args

--- a/examples/default-values/src/root_command.sh
+++ b/examples/default-values/src/root_command.sh
@@ -1,5 +1,5 @@
 echo "# This file is located at 'src/root_command.sh'."
 echo "# It contains the implementation for the 'convert' command."
-echo "# The code you write here will be wrapped by a function named 'convert_command()'."
+echo "# The code you write here will be wrapped by a function named 'root_command()'."
 echo "# Feel free to edit this file; your changes will persist when regenerating."
 inspect_args

--- a/examples/footer/src/root_command.sh
+++ b/examples/footer/src/root_command.sh
@@ -1,5 +1,5 @@
 echo "# This file is located at 'src/root_command.sh'."
 echo "# It contains the implementation for the 'download' command."
-echo "# The code you write here will be wrapped by a function named 'download_command()'."
+echo "# The code you write here will be wrapped by a function named 'root_command()'."
 echo "# Feel free to edit this file; your changes will persist when regenerating."
 inspect_args

--- a/examples/help-header-override/src/root_command.sh
+++ b/examples/help-header-override/src/root_command.sh
@@ -1,5 +1,5 @@
 echo "# This file is located at 'src/root_command.sh'."
 echo "# It contains the implementation for the 'download' command."
-echo "# The code you write here will be wrapped by a function named 'download_command()'."
+echo "# The code you write here will be wrapped by a function named 'root_command()'."
 echo "# Feel free to edit this file; your changes will persist when regenerating."
 inspect_args

--- a/examples/minimal/src/root_command.sh
+++ b/examples/minimal/src/root_command.sh
@@ -1,5 +1,5 @@
 echo "# This file is located at 'src/root_command.sh'."
 echo "# It contains the implementation for the 'download' command."
-echo "# The code you write here will be wrapped by a function named 'download_command()'."
+echo "# The code you write here will be wrapped by a function named 'root_command()'."
 echo "# Feel free to edit this file; your changes will persist when regenerating."
 inspect_args

--- a/examples/minus-v/src/root_command.sh
+++ b/examples/minus-v/src/root_command.sh
@@ -1,5 +1,5 @@
 echo "# This file is located at 'src/root_command.sh'."
 echo "# It contains the implementation for the 'cli' command."
-echo "# The code you write here will be wrapped by a function named 'cli_command()'."
+echo "# The code you write here will be wrapped by a function named 'root_command()'."
 echo "# Feel free to edit this file; your changes will persist when regenerating."
 inspect_args

--- a/examples/whitelist/src/root_command.sh
+++ b/examples/whitelist/src/root_command.sh
@@ -1,5 +1,5 @@
 echo "# This file is located at 'src/root_command.sh'."
 echo "# It contains the implementation for the 'login' command."
-echo "# The code you write here will be wrapped by a function named 'login_command()'."
+echo "# The code you write here will be wrapped by a function named 'root_command()'."
 echo "# Feel free to edit this file; your changes will persist when regenerating."
 inspect_args

--- a/lib/bashly/views/command/default_script.gtx
+++ b/lib/bashly/views/command/default_script.gtx
@@ -1,6 +1,6 @@
 > echo "# This file is located at '{{ "#{Settings.source_dir}/#{filename}" }}'."
 > echo "# It contains the implementation for the '{{ full_name }}' command."
-> echo "# The code you write here will be wrapped by a function named '{{ function_name }}_command()'."
+> echo "# The code you write here will be wrapped by a function named '{{ root_command? ? 'root' : function_name }}_command()'."
 > echo "# Feel free to edit this file; your changes will persist when regenerating."
 if Settings.enabled? :inspect_args
   > inspect_args

--- a/spec/approvals/examples/catch-all
+++ b/spec/approvals/examples/catch-all
@@ -31,14 +31,14 @@ Arguments:
 + ./download something
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[message]} = something
 + ./download something with --additional args
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[message]} = something
@@ -51,7 +51,7 @@ other_args:
 + ./download something --debug -- also pass --debug to catch_all
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--debug]} = 1

--- a/spec/approvals/examples/default-values
+++ b/spec/approvals/examples/default-values
@@ -6,7 +6,7 @@ run ./convert --help to test your bash script
 + ./convert
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'convert' command.
-# The code you write here will be wrapped by a function named 'convert_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--format]} = png
@@ -43,7 +43,7 @@ Examples:
 + ./convert '*.bmp'
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'convert' command.
-# The code you write here will be wrapped by a function named 'convert_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--format]} = png
@@ -51,7 +51,7 @@ args:
 + ./convert -f pdf
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'convert' command.
-# The code you write here will be wrapped by a function named 'convert_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--format]} = pdf
@@ -59,7 +59,7 @@ args:
 + ./convert '*.pdf' --format gif
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'convert' command.
-# The code you write here will be wrapped by a function named 'convert_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--format]} = gif

--- a/spec/approvals/examples/footer
+++ b/spec/approvals/examples/footer
@@ -6,7 +6,7 @@ run ./download --help to test your bash script
 + ./download
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args: none
 + ./download -h

--- a/spec/approvals/examples/help-header-override
+++ b/spec/approvals/examples/help-header-override
@@ -6,7 +6,7 @@ run ./download --help to test your bash script
 + ./download
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args: none
 + ./download --help

--- a/spec/approvals/examples/minimal
+++ b/spec/approvals/examples/minimal
@@ -40,7 +40,7 @@ Examples:
 + ./download somesource -f
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--force]} = 1

--- a/spec/approvals/examples/minus-v
+++ b/spec/approvals/examples/minus-v
@@ -6,7 +6,7 @@ run ./cli --help to test your bash script
 + ./cli
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args: none
 + ./cli --help
@@ -37,14 +37,14 @@ Options:
 + ./cli -v
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--verbose]} = 1
 + ./cli -h localhost -v
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--host]} = localhost

--- a/spec/approvals/examples/whitelist
+++ b/spec/approvals/examples/whitelist
@@ -49,7 +49,7 @@ region must be one of: eu, us
 + ./login eu --user admin
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'login' command.
-# The code you write here will be wrapped by a function named 'login_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[environment]} = development
@@ -61,7 +61,7 @@ args:
 + ./login eu production --user admin --protocol ssh
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'login' command.
-# The code you write here will be wrapped by a function named 'login_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[environment]} = production

--- a/spec/approvals/fixtures/catch-all-no-args
+++ b/spec/approvals/fixtures/catch-all-no-args
@@ -6,7 +6,7 @@ run ./download --help to test your bash script
 + ./download
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args: none
 + ./download --help

--- a/spec/approvals/fixtures/default-validations
+++ b/spec/approvals/fixtures/default-validations
@@ -15,7 +15,7 @@ must be an existing file
 + ./cli README.md --template cli
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[file]} = README.md

--- a/spec/approvals/fixtures/flag-args-with-dash
+++ b/spec/approvals/fixtures/flag-args-with-dash
@@ -8,14 +8,14 @@ run ./argflag --help to test your bash script
 + ./argflag -o -f
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'argflag' command.
-# The code you write here will be wrapped by a function named 'argflag_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--options]} = -f
 + ./argflag -o '--verbose --anything' -f
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'argflag' command.
-# The code you write here will be wrapped by a function named 'argflag_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--force]} = 1
@@ -29,14 +29,14 @@ run ./argflag --help to test your bash script
 + ./argflag -o -force
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'argflag' command.
-# The code you write here will be wrapped by a function named 'argflag_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--options]} = -force
 + ./argflag -o '-f -o'
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'argflag' command.
-# The code you write here will be wrapped by a function named 'argflag_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--options]} = -f -o

--- a/spec/approvals/fixtures/flag-notation
+++ b/spec/approvals/fixtures/flag-notation
@@ -6,7 +6,7 @@ run ./flags --help to test your bash script
 + ./flags -abC
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'flags' command.
-# The code you write here will be wrapped by a function named 'flags_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--alfa]} = 1
@@ -15,21 +15,21 @@ args:
 + ./flags -d=2
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'flags' command.
-# The code you write here will be wrapped by a function named 'flags_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--delta]} = 2
 + ./flags --echo=2
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'flags' command.
-# The code you write here will be wrapped by a function named 'flags_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--echo]} = 2
 + ./flags '-E=- hello world'
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'flags' command.
-# The code you write here will be wrapped by a function named 'flags_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--echo]} = - hello world

--- a/spec/approvals/fixtures/flag-private
+++ b/spec/approvals/fixtures/flag-private
@@ -6,7 +6,7 @@ run ./cli --help to test your bash script
 + ./cli
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--log]} = 3
@@ -31,7 +31,7 @@ Options:
 + ./cli --log 5
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--log]} = 5

--- a/spec/approvals/fixtures/repeatable-arg-validations
+++ b/spec/approvals/fixtures/repeatable-arg-validations
@@ -6,13 +6,13 @@ run ./cli --help to test your bash script
 + ./cli
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args: none
 + ./cli 1
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[number]} = 1
@@ -25,7 +25,7 @@ must be an integer
 + ./cli 1 2
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[number]} = 1 2

--- a/spec/approvals/fixtures/repeatable-flag-validations
+++ b/spec/approvals/fixtures/repeatable-flag-validations
@@ -6,13 +6,13 @@ run ./cli --help to test your bash script
 + ./cli
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args: none
 + ./cli --number 1
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--number]} = 1
@@ -25,7 +25,7 @@ must be an integer
 + ./cli --number 1 --number 2
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--number]} = 1 2

--- a/spec/approvals/fixtures/repeatable-whitelist
+++ b/spec/approvals/fixtures/repeatable-whitelist
@@ -6,21 +6,21 @@ run ./download --help to test your bash script
 + ./download
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--protocol]} = ftp
 + ./download -p ssh
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--protocol]} = ssh
 + ./download -p ssh -p ftp
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--protocol]} = ssh ftp

--- a/spec/approvals/fixtures/required-args-order
+++ b/spec/approvals/fixtures/required-args-order
@@ -14,7 +14,7 @@ missing required flag: --method NAME
 + ./download http 3000 --method GET
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--method]} = GET
@@ -23,7 +23,7 @@ args:
 + ./download http 3000 --method GET --role admin
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--method]} = GET
@@ -33,7 +33,7 @@ args:
 + ./download http --role admin --method GET 3000
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--method]} = GET
@@ -43,7 +43,7 @@ args:
 + ./download --role admin --method GET http 3000
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'download' command.
-# The code you write here will be wrapped by a function named 'download_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[--method]} = GET

--- a/spec/approvals/fixtures/short-flag
+++ b/spec/approvals/fixtures/short-flag
@@ -8,7 +8,7 @@ missing required flag: -o PATH
 + ./cli -o /tmp
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[-f]} = html
@@ -16,7 +16,7 @@ args:
 + ./cli -o /tmp -f json
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[-f]} = json

--- a/spec/approvals/fixtures/validation-functions
+++ b/spec/approvals/fixtures/validation-functions
@@ -11,7 +11,7 @@ run ./validate --help to test your bash script
 + ./validate 1
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'validate' command.
-# The code you write here will be wrapped by a function named 'validate_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[integer_arg]} = 1
@@ -21,7 +21,7 @@ must be an integer
 + ./validate 1 README.md
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'validate' command.
-# The code you write here will be wrapped by a function named 'validate_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[file_exists_arg]} = README.md
@@ -32,7 +32,7 @@ must be an existing file
 + ./validate 1 README.md src
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'validate' command.
-# The code you write here will be wrapped by a function named 'validate_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[dir_exists_arg]} = src
@@ -44,7 +44,7 @@ must be an existing directory
 + ./validate 1 README.md src non-empty
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'validate' command.
-# The code you write here will be wrapped by a function named 'validate_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[dir_exists_arg]} = src

--- a/spec/approvals/fixtures/whitelist-optional
+++ b/spec/approvals/fixtures/whitelist-optional
@@ -6,7 +6,7 @@ run ./cli --help to test your bash script
 + ./cli
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args: none
 + ./cli -h
@@ -40,7 +40,7 @@ action must be one of: push, commit
 + ./cli push --notify slack
 # This file is located at 'src/root_command.sh'.
 # It contains the implementation for the 'cli' command.
-# The code you write here will be wrapped by a function named 'cli_command()'.
+# The code you write here will be wrapped by a function named 'root_command()'.
 # Feel free to edit this file; your changes will persist when regenerating.
 args:
 - ${args[action]} = push


### PR DESCRIPTION
cc #659

The root command behaves slightly differently than other commands, in terms of naming.

Other commands - say `download` - have all their functions prefixed by the name of the command - `download_command`, `download_usage` etc.

The root command has a split behavior: The command function is named `root_command`, while other functions are prefixed by the CLI name - `download_usage`.

Due to this behavior, we cannot just update the `Script::Command.function_name` method:

https://github.com/bashly-framework/bashly/blob/14f1c944b754e797096f229d8002bad146b08a2a/lib/bashly/script/command.rb#L67-L69

and instead, we have to address this particular case with a local template condition:

```bash
> echo "# The code you write here will be wrapped by a function named '{{ root_command? ? 'root' : function_name }}_command()'."
```
