### PR TITLE
Fix validation running twice for environment variables

### DIFF
--- a/lib/bashly/script/argument.rb
+++ b/lib/bashly/script/argument.rb
@@ -21,12 +21,12 @@ module Bashly
         end
       end
 
-      def usage_string
-        required ? label : "[#{label}]"
-      end
-
       def label
         repeatable ? "#{name.upcase}..." : name.upcase
+      end
+
+      def usage_string
+        required ? label : "[#{label}]"
       end
     end
   end

--- a/lib/bashly/script/environment_variable.rb
+++ b/lib/bashly/script/environment_variable.rb
@@ -6,7 +6,7 @@ module Bashly
       class << self
         def option_keys
           @option_keys ||= %i[
-            allowed default help name required private validate
+            allowed default help name private required validate
           ]
         end
       end

--- a/lib/bashly/script/flag.rb
+++ b/lib/bashly/script/flag.rb
@@ -10,7 +10,7 @@ module Bashly
         def option_keys
           @option_keys ||= %i[
             allowed arg completions conflicts default help long needs
-            repeatable required short unique validate private
+            private repeatable required short unique validate
           ]
         end
       end

--- a/lib/bashly/views/argument/validations.gtx
+++ b/lib/bashly/views/argument/validations.gtx
@@ -14,10 +14,12 @@ if validate
     >   done
     > fi
   else
-    > validation_output="$(validate_{{ validate }} "${args['{{ name }}']:-}")"
-    > if [[ -v args['{{ name }}'] && -n "$validation_output" ]]; then
-    >   printf "{{ strings[:validation_error] }}\n" "{{ name.upcase }}" "$validation_output" >&2
-    >   exit 1
+    > if [[ -v args['{{ name }}'] ]]; then
+    >   validation_output="$(validate_{{ validate }} "${args['{{ name }}']:-}")"
+    >   if [[ -n "$validation_output" ]]; then
+    >     printf "{{ strings[:validation_error] }}\n" "{{ name.upcase }}" "$validation_output" >&2
+    >     exit 1
+    >   fi
     > fi
     >
   end

--- a/lib/bashly/views/environment_variable/validations.gtx
+++ b/lib/bashly/views/environment_variable/validations.gtx
@@ -1,9 +1,12 @@
 if validate
   = view_marker
 
-  > if [[ -v {{ name.upcase }} && -n $(validate_{{ validate }} "${{ name.upcase }}") ]]; then
-  >   printf "{{ strings[:environment_variable_validation_error] }}\n" "{{ usage_string }}" "$(validate_{{ validate }} "${{ name.upcase }}")" >&2
-  >   exit 1
+  > if [[ -v {{ name.upcase }} ]]; then
+  >   validation_output="$(validate_{{ validate }} "${{ name.upcase }}")"
+  >   if [[ -n "${validation_output}" ]]; then
+  >     printf "{{ strings[:environment_variable_validation_error] }}\n" "{{ usage_string }}" "$validation_output" >&2
+  >     exit 1
+  >   fi
   > fi
   >
 end


### PR DESCRIPTION
cc #626, @meleu 

This fixes the validation running twice for environment variables, as was previously fixed for arguments and flags.