### PR TITLE
Add support for per-environment settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,8 +37,9 @@ RSpec/SpecFilePathFormat:
     - 'spec/bashly/concerns/completions_command_spec.rb'
     - 'spec/bashly/concerns/completions_flag_spec.rb'
 
-# Allow longer integration examples as they are more complex by nature
+# Allow longer examples in some cases
 RSpec/ExampleLength:
   Exclude:
     - 'spec/bashly/integration/**/*'
     - 'spec/bashly/libraries/render*'
+    - 'spec/bashly/script/command_spec.rb'

--- a/lib/bashly/libraries/settings/settings.yml
+++ b/lib/bashly/libraries/settings/settings.yml
@@ -1,14 +1,41 @@
-# All settings are optional (with their default values provided below), and
-# can also be set with an environment variable with the same name, capitalized
-# and prefixed by `BASHLY_` - for example: BASHLY_SOURCE_DIR
+#-------------------------------------------------------------------------------
+# BASHLY SETTINGS
+#-------------------------------------------------------------------------------
 #
-# When setting environment variables, you can use:
-# - "0", "false" or "no" to represent false
-# - "1", "true" or "yes" to represent true
+### Default Values
 #
-# If you wish to change the path to this file, set the environment variable
-# BASHLY_SETTINGS_PATH.
-
+#   All settings are optional, with their default values provided below
+#
+### Environment Variables
+#
+#   Values can also be set using an environment variable with the same name,
+#   capitalized and prefixed by `BASHLY_` - for example: `BASHLY_SOURCE_DIR`
+#
+#   When setting environment variables, you can use:
+#   - "0", "false" or "no" to represent false
+#   - "1", "true" or "yes" to represent true
+#
+#   Environment variables take precedence over values in the config file.
+#
+### File Location:
+#
+#   Bashly looks for the settings file in these locations.
+#   - The path defined in the `BASHLY_SETTINGS_PATH` environment variable.
+#   - A file named `bashly-settings.yml` in the working directory.
+#   - A file named `settings.yml` in the working directory.
+#
+### Environment Overrides:
+#
+#   All options (except `env`) may be specified with an environment suffix in 
+#   order to override its value for a given environment.
+#
+#   For example, when defining `formatter_production: shfmt --minify`, then 
+#   this will be the formatter used when generating the script with
+#   `bashly generate --env production`
+#
+#   Since these values take precedence over the standard values, you can define
+#   both (i.e. `formatter: shfmt` and `formatter_production: shfmt --minify`).
+#
 
 #-------------------------------------------------------------------------------
 # PATH OPTIONS
@@ -52,12 +79,12 @@ strict: false
 tab_indent: false
 
 # Choose a post-processor for the generated script:
-# formatter: internal     # Use Bashly's internal formatter (compacts newlines)
+# formatter: internal     # Use Bashly’s built-in formatter (removes extra newlines)
 # formatter: external     # Run the external command `shfmt --case-indent --indent 2`
 # formatter: none         # Disable formatting entirely
-# formatter: <string>     # Use a custom shell command to format the script.
-#                         # The command will receive the script via stdin and
-#                         # must output the result to stdout.
+# formatter: <string>     # Provide a custom shell command to format the script.
+#                         # The command receives the script via stdin and must
+#                         # write the result to stdout.
 #                         # Example: shfmt --minify
 formatter: internal
 
@@ -102,7 +129,7 @@ usage_colors:
 #-------------------------------------------------------------------------------
 
 # Set to 'production' or 'development'.
-# Determines which features are enabled in the rendered script.
+# Determines which features are enabled in the generated script.
 # Use the `enable_*` options below to adjust settings for each environment.
 # It is recommended to leave this set to 'development' and run
 # `bashly generate --env production` when the production version is needed.

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -160,11 +160,22 @@ module Bashly
     private
 
       def get(key)
+        value_from_env(key) || value_from_config(key)
+      end
+
+      def value_from_config(key)
+        if key != :env
+          config["#{key}_#{env}"] || config["#{key}"]
+        else
+          config["#{key}"]
+        end
+      end
+
+      def value_from_env(key)
         case env_value key
-        when nil                 then config[key.to_s]
         when '0', 'false', 'no'  then false
         when '1', 'true', 'yes'  then true
-        else                     env_value key
+        else env_value key
         end
       end
 

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -160,27 +160,27 @@ module Bashly
     private
 
       def get(key)
-        value_from_env(key) || value_from_config(key)
+        ENV.has_key?(env_var_name(key)) ? value_from_env(key) : value_from_config(key)
+      end
+
+      def env_var_name(key)
+        "BASHLY_#{key.upcase}"
       end
 
       def value_from_config(key)
-        if key != :env
-          config["#{key}_#{env}"] || config["#{key}"]
-        else
-          config["#{key}"]
-        end
+        return config[key.to_s] if key == :env
+
+        result = config["#{key}_#{env}"]
+        result.nil? ? config[key.to_s] : result
       end
 
       def value_from_env(key)
-        case env_value key
-        when '0', 'false', 'no'  then false
-        when '1', 'true', 'yes'  then true
-        else env_value key
+        result = ENV[env_var_name(key)]
+        case result&.strip&.downcase
+        when '0', 'false', 'no' then false
+        when '1', 'true', 'yes' then true
+        else result
         end
-      end
-
-      def env_value(key)
-        ENV["BASHLY_#{key.upcase}"]
       end
 
       def config

--- a/spec/bashly/settings_spec.rb
+++ b/spec/bashly/settings_spec.rb
@@ -74,6 +74,28 @@ describe Settings do
         expect(subject.tab_indent).to eq ENV['BASHLY_TAB_INDENT']
       end
     end
+
+    context 'when using env suffix overrides' do
+      before do
+        reset_tmp_dir
+        File.write 'spec/tmp/settings.yml', 'formatter_production: shfmt --minify'
+        subject.formatter = nil
+      end
+
+      it 'returns the default value when it is not the specified environment' do
+        Dir.chdir 'spec/tmp' do
+          expect(subject.formatter).to eq 'internal'
+        end
+      end
+
+      it 'returns the config value when it is the specified environment' do
+        Dir.chdir 'spec/tmp' do
+          subject.env = :production
+          expect(subject.formatter).to eq 'shfmt --minify'
+        end
+      end
+    end
+
   end
 
   describe '::env' do

--- a/spec/bashly/settings_spec.rb
+++ b/spec/bashly/settings_spec.rb
@@ -95,7 +95,6 @@ describe Settings do
         end
       end
     end
-
   end
 
   describe '::env' do


### PR DESCRIPTION
As discussed in #665 and raised in #664.

This adds the ability to add `_production` or `_development` suffix to all option names in the settings.

---

- [x] Implementation
- [x] Specs
- [x] Documentation - [Source](https://github.com/bashly-framework/bashly-book/commit/3fadf9080af8c82e18ab044f21fcae65818e9655) / [Preview](https://v1-3-3.bashly-book.pages.dev/usage/settings/#environment-overrides)
