### PR TITLE
Add support for additional settings file names

### DIFF
--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -181,13 +181,12 @@ module Bashly
       end
 
       def user_settings_path
-        @user_settings_path ||= if ENV['BASHLY_SETTINGS_PATH']
-          ENV['BASHLY_SETTINGS_PATH']
-        elsif File.exist? 'bashly-settings.yml'
-          'bashly-settings.yml'
-        else
-          'settings.yml'
-        end
+        @user_settings_path ||= ENV['BASHLY_SETTINGS_PATH'] || [
+          '.bashly.yml', 'bashly.yml',
+          '.bashly-settings.yml', 'bashly-settings.yml',
+          '.bashlyrc.yml', 'bashlyrc.yml',
+          '.settings.yml'
+        ].find { |f| File.exist?(f) } || 'settings.yml'
       end
 
       def default_settings

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -182,7 +182,6 @@ module Bashly
 
       def user_settings_path
         @user_settings_path ||= ENV['BASHLY_SETTINGS_PATH'] || [
-          '.bashly.yml', 'bashly.yml',
           '.bashly-settings.yml', 'bashly-settings.yml',
           '.bashlyrc.yml', 'bashlyrc.yml',
           '.settings.yml'

--- a/spec/bashly/settings_spec.rb
+++ b/spec/bashly/settings_spec.rb
@@ -20,10 +20,94 @@ describe Settings do
       end
     end
 
+    context 'when .settings.yml exists' do
+      before do
+        reset_tmp_dir
+        File.write 'spec/tmp/.settings.yml', 'source_dir: somedir'
+        subject.source_dir = nil
+      end
+
+      it 'returns the value from the settings file' do
+        Dir.chdir 'spec/tmp' do
+          expect(subject.source_dir).to eq 'somedir'
+        end
+      end
+    end
+
+    context 'when bashlyrc.yml exists' do
+      before do
+        reset_tmp_dir
+        File.write 'spec/tmp/bashlyrc.yml', 'source_dir: somedir'
+        subject.source_dir = nil
+      end
+
+      it 'returns the value from the settings file' do
+        Dir.chdir 'spec/tmp' do
+          expect(subject.source_dir).to eq 'somedir'
+        end
+      end
+    end
+
+    context 'when .bashlyrc.yml exists' do
+      before do
+        reset_tmp_dir
+        File.write 'spec/tmp/.bashlyrc.yml', 'source_dir: somedir'
+        subject.source_dir = nil
+      end
+
+      it 'returns the value from the settings file' do
+        Dir.chdir 'spec/tmp' do
+          expect(subject.source_dir).to eq 'somedir'
+        end
+      end
+    end
+
     context 'when bashly-settings.yml exists' do
       before do
         reset_tmp_dir
         File.write 'spec/tmp/bashly-settings.yml', 'source_dir: somedir'
+        subject.source_dir = nil
+      end
+
+      it 'returns the value from the settings file' do
+        Dir.chdir 'spec/tmp' do
+          expect(subject.source_dir).to eq 'somedir'
+        end
+      end
+    end
+
+    context 'when .bashly-settings.yml exists' do
+      before do
+        reset_tmp_dir
+        File.write 'spec/tmp/.bashly-settings.yml', 'source_dir: somedir'
+        subject.source_dir = nil
+      end
+
+      it 'returns the value from the settings file' do
+        Dir.chdir 'spec/tmp' do
+          expect(subject.source_dir).to eq 'somedir'
+        end
+      end
+    end
+
+    context 'when bashly.yml exists' do
+      before do
+        reset_tmp_dir
+        File.write 'spec/tmp/bashly.yml', 'source_dir: somedir'
+        subject.source_dir = nil
+      end
+
+      it 'returns the value from the settings file' do
+        Dir.chdir 'spec/tmp' do
+          expect(subject.source_dir).to eq 'somedir'
+        end
+      end
+    end
+
+    context 'when .bashly.yml exists' do
+      before do
+        reset_tmp_dir
+        File.write 'spec/tmp/.bashly.yml', 'source_dir: somedir'
         subject.source_dir = nil
       end
 

--- a/spec/bashly/settings_spec.rb
+++ b/spec/bashly/settings_spec.rb
@@ -90,34 +90,6 @@ describe Settings do
       end
     end
 
-    context 'when bashly.yml exists' do
-      before do
-        reset_tmp_dir
-        File.write 'spec/tmp/bashly.yml', 'source_dir: somedir'
-        subject.source_dir = nil
-      end
-
-      it 'returns the value from the settings file' do
-        Dir.chdir 'spec/tmp' do
-          expect(subject.source_dir).to eq 'somedir'
-        end
-      end
-    end
-
-    context 'when .bashly.yml exists' do
-      before do
-        reset_tmp_dir
-        File.write 'spec/tmp/.bashly.yml', 'source_dir: somedir'
-        subject.source_dir = nil
-      end
-
-      it 'returns the value from the settings file' do
-        Dir.chdir 'spec/tmp' do
-          expect(subject.source_dir).to eq 'somedir'
-        end
-      end
-    end
-
     context 'when BASHLY_SETTINGS_PATH is set' do
       before do
         reset_tmp_dir


### PR DESCRIPTION
This pull request proposes support for additional names for the settings file.

In addition to `bashly-settings.yml` and `settings.yml`, Bashly would also support `bashlyrc.yml`, as well as dotted versions of all three. This means it would recognize the following files, in this order, as the settings file:

- `.bashly-settings.yml`
- `bashly-settings.yml`
- `.bashlyrc.yml`
- `bashlyrc.yml`
- `.settings.yml`
- `settings.yml`

Note that `bashly.yml` (and its dotted version) was intentionally excluded to avoid confusion with the main configuration file.

This naming format tries to follow a convention adopted by other tools. While it is not a strict rule, I believe other developers might appreciate the added flexibility.

These naming choices are arbitrary. Any feedback or suggestions are welcome.

---

_This was my first experience with Ruby, so I hope this doesn't cause any issues!_ 🙂