### PR TITLE
Allow disabling and overriding argfile with env var

### DIFF
--- a/lib/bashly/libraries/settings/settings.yml
+++ b/lib/bashly/libraries/settings/settings.yml
@@ -120,6 +120,12 @@ show_examples_on_error: false
 # all the private elements in the usage texts, as if they were public.
 private_reveal_key: ~
 
+# When enabling argfile for any command, this setting controls the name of the
+# environment variable that can override or disable argfile loading at runtime.
+# Set the variable to `0`, `off`, `no` or `false` to disable argfile loading,
+# or to a different path to load another argfile instead.
+argfile_var: ARGFILE
+
 # Display various usage elements in color by providing the name of the color
 # function. The value for each property is a name of a function that is
 # available in your script, for example: `green` or `bold`.

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -4,6 +4,7 @@ module Bashly
       include AssetHelper
 
       attr_writer(
+        :argfile_var,
         :commands_dir,
         :compact_short_flags,
         :conjoined_flag_args,
@@ -35,6 +36,10 @@ module Bashly
 
       def all_lib_dirs
         @all_lib_dirs = [full_lib_dir] + extra_lib_dirs
+      end
+
+      def argfile_var
+        @argfile_var ||= get :argfile_var
       end
 
       def commands_dir

--- a/lib/bashly/views/command/argfile_filter.gtx
+++ b/lib/bashly/views/command/argfile_filter.gtx
@@ -1,18 +1,29 @@
 = view_marker
 
-> local argfile_line argfile_key argfile_value escaped
-> [[ -f "{{ argfile }}" ]] || return
+> local argfile argfile_line argfile_key argfile_value escaped env_argfile env_argfile_var
+> argfile="{{ argfile }}"
+> env_argfile_var="{{ Settings.argfile_var }}"
+> env_argfile="${!env_argfile_var:-}"
 >
-> while IFS= read -r argfile_line || [[ -n "$argfile_line" ]]; do
->   [[ "$argfile_line" =~ ^[[:space:]]*(-{1,2}[^[:space:]]+)([[:space:]]+(.+))?[[:space:]]*$ ]] || continue
->   argfile_key="${BASH_REMATCH[1]}"
->   argfile_value="${BASH_REMATCH[3]:-}"
->   argfile_value="${argfile_value#"${argfile_value%%[![:space:]]*}"}"
->   argfile_value="${argfile_value%"${argfile_value##*[![:space:]]}"}"
->   [[ "$argfile_value" =~ ^\"(.*)\"$ || "$argfile_value" =~ ^\'(.*)\'$ ]] && argfile_value="${BASH_REMATCH[1]}"
+> case "${env_argfile,,}" in
+>   0 | off | no | false)
+>     argfile=''
+>     ;;
+> esac
 >
->   case "$argfile_key" in
+> [[ -n "$env_argfile" ]] && argfile="$env_argfile"
+> if [[ -f "$argfile" ]]; then
+>   while IFS= read -r argfile_line || [[ -n "$argfile_line" ]]; do
+>     [[ "$argfile_line" =~ ^[[:space:]]*(-{1,2}[^[:space:]]+)([[:space:]]+(.+))?[[:space:]]*$ ]] || continue
+>     argfile_key="${BASH_REMATCH[1]}"
+>     argfile_value="${BASH_REMATCH[3]:-}"
+>     argfile_value="${argfile_value#"${argfile_value%%[![:space:]]*}"}"
+>     argfile_value="${argfile_value%"${argfile_value##*[![:space:]]}"}"
+>     [[ "$argfile_value" =~ ^\"(.*)\"$ || "$argfile_value" =~ ^\'(.*)\'$ ]] && argfile_value="${BASH_REMATCH[1]}"
+>
+>     case "$argfile_key" in
 = flags.map { |flag| flag.render(:argfile_case) }.join.indent 4
->   esac
-> done <"{{ argfile }}"
+>     esac
+>   done <"$argfile"
+> fi
 >

--- a/lib/bashly/views/command/argfile_filter.gtx
+++ b/lib/bashly/views/command/argfile_filter.gtx
@@ -1,6 +1,6 @@
 = view_marker
 
-> local argfile argfile_line argfile_key argfile_value escaped env_argfile env_argfile_var
+> local argfile argfile_line argfile_key argfile_value env_argfile env_argfile_var
 > argfile="{{ argfile }}"
 > env_argfile_var="{{ Settings.argfile_var }}"
 > env_argfile="${!env_argfile_var:-}"
@@ -22,7 +22,7 @@
 >     [[ "$argfile_value" =~ ^\"(.*)\"$ || "$argfile_value" =~ ^\'(.*)\'$ ]] && argfile_value="${BASH_REMATCH[1]}"
 >
 >     case "$argfile_key" in
-= flags.map { |flag| flag.render(:argfile_case) }.join.indent 4
+= flags.map { |flag| flag.render(:argfile_case) }.join.indent 6
 >     esac
 >   done <"$argfile"
 > fi

--- a/schemas/settings.json
+++ b/schemas/settings.json
@@ -289,6 +289,13 @@
         }
       ]
     },
+    "argfile_var": {
+      "title": "argfile var",
+      "description": "The name of the environment variable that can override or disable command argfiles at runtime\nhttps://bashly.dev/usage/settings/#argfile_var",
+      "type": "string",
+      "minLength": 1,
+      "default": "ARGFILE"
+    },
     "watch_evented": {
       "title": "watch evented",
       "description": "Whether to use evented file system watch instead of the default polling\nhttps://bashly.dev/usage/settings/#watch_evented",

--- a/spec/approvals/fixtures/argfile-env-var
+++ b/spec/approvals/fixtures/argfile-env-var
@@ -1,0 +1,30 @@
+creating user files in src
+created src/root_command.sh
+created ./download
+run ./download --help to test your bash script
++ ./download somesource
+# This file is located at 'src/root_command.sh'.
+# It contains the implementation for the 'download' command.
+# The code you write here will be wrapped by a function named 'root_command()'.
+# Feel free to edit this file; your changes will persist when regenerating.
+args:
+- ${args[--force]} = 1
+- ${args[--log]} = from-default.log
+- ${args[source]} = somesource
++ DOWNLOAD_ARGFILE=off
++ ./download somesource
+# This file is located at 'src/root_command.sh'.
+# It contains the implementation for the 'download' command.
+# The code you write here will be wrapped by a function named 'root_command()'.
+# Feel free to edit this file; your changes will persist when regenerating.
+args:
+- ${args[source]} = somesource
++ DOWNLOAD_ARGFILE=.alt-download
++ ./download somesource
+# This file is located at 'src/root_command.sh'.
+# It contains the implementation for the 'download' command.
+# The code you write here will be wrapped by a function named 'root_command()'.
+# Feel free to edit this file; your changes will persist when regenerating.
+args:
+- ${args[--log]} = from-override.log
+- ${args[source]} = somesource

--- a/spec/fixtures/workspaces/argfile-env-var/.alt-download
+++ b/spec/fixtures/workspaces/argfile-env-var/.alt-download
@@ -1,0 +1,1 @@
+--log from-override.log

--- a/spec/fixtures/workspaces/argfile-env-var/.download
+++ b/spec/fixtures/workspaces/argfile-env-var/.download
@@ -1,0 +1,2 @@
+--force
+--log from-default.log

--- a/spec/fixtures/workspaces/argfile-env-var/.gitignore
+++ b/spec/fixtures/workspaces/argfile-env-var/.gitignore
@@ -1,0 +1,2 @@
+download
+src/*.sh

--- a/spec/fixtures/workspaces/argfile-env-var/settings.yml
+++ b/spec/fixtures/workspaces/argfile-env-var/settings.yml
@@ -1,0 +1,1 @@
+argfile_var: DOWNLOAD_ARGFILE

--- a/spec/fixtures/workspaces/argfile-env-var/src/bashly.yml
+++ b/spec/fixtures/workspaces/argfile-env-var/src/bashly.yml
@@ -1,0 +1,19 @@
+name: download
+help: Test argfile env var behavior
+version: 0.1.0
+
+argfile: .download
+
+args:
+- name: source
+  required: true
+  help: URL to download from
+
+flags:
+- long: --force
+  short: -f
+  help: Overwrite existing files
+- long: --log
+  short: -l
+  arg: path
+  help: Path to log file

--- a/spec/fixtures/workspaces/argfile-env-var/test.sh
+++ b/spec/fixtures/workspaces/argfile-env-var/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+rm -f ./download
+rm -f ./src/*.sh
+
+bundle exec bashly generate
+
+set -x
+
+./download somesource
+DOWNLOAD_ARGFILE=off ./download somesource
+DOWNLOAD_ARGFILE=.alt-download ./download somesource

--- a/support/schema/settings.yml
+++ b/support/schema/settings.yml
@@ -237,6 +237,14 @@ properties:
       The name of the environment variable (case sensitive) that, if set, will reveal private commands, flags and environment variables
       https://bashly.dev/usage/settings/#private_reveal_key
     oneOf: *optional_string
+  argfile_var:
+    title: argfile var
+    description: |-
+      The name of the environment variable that can override or disable command argfiles at runtime
+      https://bashly.dev/usage/settings/#argfile_var
+    type: string
+    minLength: 1
+    default: ARGFILE
   watch_evented:
     title: watch evented
     description: |-


### PR DESCRIPTION
This PR adds a user-level escape hatch from loading command argfiles, if they are in play.

- Setting `ARGFILE=no` (or `0`, `off` or `false`) will disable argfile use
- Setting `ARGFILE=other-file` will load this file instead

The name of that variable can be changed in `settings.yml` using `argfile_var`