### PR TITLE
Remove `lp` dependency

### DIFF
--- a/bashly.gemspec
+++ b/bashly.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'colsole', '~> 1.0'
   s.add_dependency 'gtx', '~> 0.1.1'
-  s.add_dependency 'lp', '~> 0.2.0'
   s.add_dependency 'mister_bin', '~> 0.9.0'
   s.add_dependency 'requires', '~> 1.1'
   s.add_dependency 'tty-markdown', '~> 0.7.2'

--- a/lib/bashly/commands/validate.rb
+++ b/lib/bashly/commands/validate.rb
@@ -1,5 +1,3 @@
-require 'lp'
-
 module Bashly
   module Commands
     class Validate < Base
@@ -13,7 +11,7 @@ module Bashly
 
       def run
         if args['--verbose']
-          lp config
+          puts config.to_yaml
           puts '---'
         end
         validate_config


### PR DESCRIPTION
Used only by `bashly validate --verbose`m which will now print the YAML config without colors.